### PR TITLE
Give the link checker action permission to create issues

### DIFF
--- a/.github/workflows/broken-link-check.yaml
+++ b/.github/workflows/broken-link-check.yaml
@@ -11,9 +11,12 @@ jobs:
   broken-link-check:
     name: Broken Link Check
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Broken Link Check
         uses: technote-space/broken-link-checker-action@v2
         with:
           TARGET: https://mf1-btr.github.io/
           RECURSIVE: true
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
The link checking action can directly create issues for broken links. To do this it needs additional permissions, so we try to add these here. I'm not sure if we need to generate an additional token or if it's done automatically.
